### PR TITLE
fix bluetooth problems with Windows

### DIFF
--- a/PuffcoPython/main.py
+++ b/PuffcoPython/main.py
@@ -88,7 +88,7 @@ async def getDeviceName():
     return name.decode()
 
 async def sendCommand(client, commandArray):
-    await client.write_gatt_char(COMMAND, commandArray)
+    await client.write_gatt_char(COMMAND, commandArray, response=True)
 
 async def sendLanternColour(client, colour):
     await client.write_gatt_char(LANTERN_COLOUR, colour)
@@ -191,7 +191,8 @@ async def handle_cmd():
 @app.route('/')
 async def index():
     try:
-        await asyncio.wait_for(client.connect(), timeout=7.5)
+        await client.connect(timeout=7.5)
+        await client.pair()
         print(f"Connected: {client.is_connected}\n")
         return f"Connected to {await getDeviceName()}", 200
     except asyncio.TimeoutError:


### PR DESCRIPTION
tested on two different Windows computers, both were able to connect and preheat using my profiles.

If you get the error `Device with address <MAC ADDRESS> was not found`:

1.  Hold the power button on the Peak Pro until it flashes/pulses blue. 
2. Access `127.0.0.1:8080` in your web browser, which _should_ successfully establish the connection.

** To test the preheating, access `127.0.0.1:8080/cmd?command=preheat&profile=2` (profile can be anything, 1-4)